### PR TITLE
fix(migrate): raise PHP timeout + memory for ciphra-export

### DIFF
--- a/src/Controller/CiphraMigrationController.php
+++ b/src/Controller/CiphraMigrationController.php
@@ -89,6 +89,14 @@ class CiphraMigrationController extends AbstractController
         EpilepcBundleSerializer $serializer,
         CiphraExportRateLimiter $rateLimiter
     ): Response {
+        // defuse/php-encryption runs PBKDF2 per encrypted record, so users
+        // with hundreds of seizures hit the default 30s PHP timeout.
+        // 300s + 512M is generous headroom; proper fix is key-derive-once
+        // refactor (P2, tracked separately). Bumped 2026-06-11 after first
+        // migrant timeout.
+        @set_time_limit(300);
+        @ini_set('memory_limit', '512M');
+
         $corsHeaders = $this->corsHeaders($request);
 
         if ($request->getMethod() === 'OPTIONS') {


### PR DESCRIPTION
## Summary
First production migration hit PHP's default 30s `max_execution_time` in `defuse/php-encryption/Core.php:429` (PBKDF2 per encrypted record × N seizures = death). 300s + 512M is generous headroom for the largest expected user; proper fix is a key-derive-once refactor (tracked as P2 — defer until/unless we see real users hit this with 300s too).

## Test plan
- [ ] Pull on prod, `bin/console cache:clear --env=prod`
- [ ] Generate fresh migration link, run end-to-end migration of largest test user
- [ ] Verify `var/log/prod.log` no longer shows the timeout exception