### PR TITLE
Fix /de/admin 500 + read-only UI gating + banner/nav polish

### DIFF
--- a/src/Controller/UserAdminController.php
+++ b/src/Controller/UserAdminController.php
@@ -22,20 +22,37 @@ class UserAdminController extends AbstractController
     /**
      * @Route("/admin", name="admin_user_index")
      * Visualisiert die Benutzerübersicht
+     *
+     * The list is paginated server-side: each row decrypts firstname+lastname
+     * (Defuse PBKDF2, ~74ms each), so rendering every user at once exceeded the
+     * host's 30s execution cap once the user base passed ~200. The overview
+     * metrics are counted via SQL over ALL users (cheap, unencrypted columns)
+     * so they are not limited to the current page.
      */
-    public function index(UserRepository $userRepository){
+    public function index(Request $request, UserRepository $userRepository){
 
-        set_time_limit(300);
-        #$em = $this->getDoctrine()->getManager();
-        #$query = $em->createQuery('SELECT u FROM App\Entity\User u')
-        #    ->setCacheable(true)
-        #    ->setCacheMode('NORMAL');
-    
-        #$users = $query->getResult();
-        
+        $perPage = 25;
+        $page = max(1, (int) $request->query->get('page', 1));
+
+        $paginator = $userRepository->findPaginated($page, $perPage);
+        $total = $userRepository->countAll();
+        $totalPages = (int) max(1, ceil($total / $perPage));
+
+        // Clamp out-of-range page requests to the last real page.
+        if ($page > $totalPages) {
+            $page = $totalPages;
+            $paginator = $userRepository->findPaginated($page, $perPage);
+        }
+
         return $this->render('user_admin/index.html.twig', [
-            'users' => $userRepository->findAll()
-        #    'users' => $users
+            'users' => $paginator,
+            'page' => $page,
+            'perPage' => $perPage,
+            'totalPages' => $totalPages,
+            'total_count' => $total,
+            'admin_count' => $userRepository->countAdmins(),
+            'deactivated_count' => $userRepository->countDeactivated(),
+            'migrated_count' => $userRepository->countMigrated(),
         ]);
 
     }

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -4,6 +4,7 @@ namespace App\Repository;
 
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -19,6 +20,66 @@ class UserRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, User::class);
+    }
+
+    /**
+     * One page of users, newest registration first. Only this slice is
+     * hydrated/decrypted — the admin index decrypts firstname+lastname per
+     * row, and each Defuse decrypt runs a 100k-iteration PBKDF2 (~74ms), so
+     * loading every user blows past the 30s execution cap once the user base
+     * grows past ~200. Pagination bounds the per-request decrypt count.
+     */
+    public function findPaginated(int $page, int $perPage): Paginator
+    {
+        $query = $this->createQueryBuilder('u')
+            ->orderBy('u.agreedTermsAt', 'DESC')
+            ->setFirstResult(($page - 1) * $perPage)
+            ->setMaxResults($perPage)
+            ->getQuery();
+
+        return new Paginator($query, false);
+    }
+
+    /**
+     * Aggregate counts for the admin overview cards. Computed over ALL users
+     * via SQL COUNT() — never over the paginated slice — so the metrics stay
+     * correct regardless of which page is shown. roles/deactivated/migrated_at
+     * are plain columns (not encrypted), so these are cheap.
+     */
+    public function countAll(): int
+    {
+        return (int) $this->createQueryBuilder('u')
+            ->select('count(u.id)')
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    public function countAdmins(): int
+    {
+        return (int) $this->createQueryBuilder('u')
+            ->select('count(u.id)')
+            ->andWhere('u.roles LIKE :admin')
+            ->setParameter('admin', '%ROLE_ADMIN%')
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    public function countDeactivated(): int
+    {
+        return (int) $this->createQueryBuilder('u')
+            ->select('count(u.id)')
+            ->andWhere('u.deactivated = 1')
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    public function countMigrated(): int
+    {
+        return (int) $this->createQueryBuilder('u')
+            ->select('count(u.id)')
+            ->andWhere('u.migrated_at IS NOT NULL')
+            ->getQuery()
+            ->getSingleScalarResult();
     }
 
     public function translateMonth($month_name, $lang)

--- a/templates/_partials/lifecycle_banner.html.twig
+++ b/templates/_partials/lifecycle_banner.html.twig
@@ -35,7 +35,11 @@
         align-items: center !important;
         flex-wrap: wrap !important;
         gap: 12px !important;
-        padding: 12px 20px !important;
+        /* Right padding reserves the 36px top-right slot for the × button at
+           ALL widths. The × is out of flow (position:absolute), so flex never
+           reserves space for it — without this reservation the CTA/text run
+           under the × on desktop. */
+        padding: 12px 52px 12px 20px !important;
     }
     .ciphra-lifecycle-banner,
     .ciphra-lifecycle-banner * {
@@ -69,6 +73,15 @@
         right: 4px !important;
         width: 36px !important;
         height: 36px !important;
+        /* The landing page's main.css styles ALL <button> elements with
+           `min-width: 9.25em; padding: 0 1.5em` — at the inherited font that
+           blows the × up to ~204px wide, so it sails left over the CTA. width
+           alone can't beat min-width, so pin min/max-width and zero the padding
+           explicitly. flex:0 0 36px keeps it from being stretched as a flex item. */
+        min-width: 36px !important;
+        max-width: 36px !important;
+        padding: 0 !important;
+        flex: 0 0 36px !important;
         display: inline-flex !important;
         align-items: center !important;
         justify-content: center !important;
@@ -91,11 +104,10 @@
        reservation to avoid running under it on a single line. */
     @media (max-width: 768px) {
         .ciphra-lifecycle-banner {
-            padding: 10px 14px !important;
+            padding: 10px 44px 10px 14px !important; /* keep the × slot reserved */
             gap: 8px !important;
         }
         .ciphra-lifecycle-banner .lifecycle-text {
-            padding-right: 28px !important; /* reserve space for the × */
             flex: 1 1 100% !important;
             min-width: 0 !important;
         }
@@ -115,7 +127,7 @@
             line-height: 1.45 !important;
         }
         .ciphra-lifecycle-banner {
-            padding: 10px 12px !important;
+            padding: 10px 40px 10px 12px !important; /* keep the × slot reserved */
         }
     }
 </style>

--- a/templates/app/base.html.twig
+++ b/templates/app/base.html.twig
@@ -209,9 +209,8 @@
                         <!-- ciphra migration entry — always visible while the
                              deprecation lifecycle is active. -->
                         <li class="nav-item d-none d-md-block">
-                            <a class="nav-link" href="{{ path('app_landingpage_info_ciphra') }}"
-                               style="color: #b23c2c; font-weight: 600;">
-                                {% trans %}Wechsel zu ciphra{% endtrans %}
+                            <a class="nav-link text-gray-700" href="{{ path('app_landingpage_info_ciphra') }}" style="font-weight: 600;">
+                                {% trans %}Über ciphra{% endtrans %}
                             </a>
                         </li>
                         <div class="topbar-divider d-none d-sm-block"></div>

--- a/templates/app/diaryentry/index.html.twig
+++ b/templates/app/diaryentry/index.html.twig
@@ -7,9 +7,11 @@
     <div class="mb-5">
         <div class="text-center">
             <h1 class="h3 text-gray-800 justify-content-center border-bottom pb-2 mb-2">{% trans %}Tagebuchübersicht{% endtrans %}</h1>
-            <p class="mb-4">{% trans %}Untenstehend findest du alle deine erfassten{% endtrans %} {% trans %}Tagebucheinträge{% endtrans %}. <br />{% trans %}Zusätzlich kannst du auf das Pluszeichen{% endtrans %} <i class="fas fa-plus-circle"></i> {% trans %}klicken, um einen neuen Tagebucheintrag zu erstellen{% endtrans %}</p>
+            <p class="mb-4">{% trans %}Untenstehend findest du alle deine erfassten{% endtrans %} {% trans %}Tagebucheinträge{% endtrans %}.{% if not is_locked %} <br />{% trans %}Zusätzlich kannst du auf das Pluszeichen{% endtrans %} <i class="fas fa-plus-circle"></i> {% trans %}klicken, um einen neuen Tagebucheintrag zu erstellen{% endtrans %}{% endif %}</p>
 
+            {% if not is_locked %}
             <a href="{{ path('diaryentry_new') }}" title="{% trans %}Neuer Tagebucheintrag erstellen{% endtrans %}"><i class="fas fa-plus-circle fa-3x text-diary"></i></a>
+            {% endif %}
         </div>
     </div>
 
@@ -36,7 +38,13 @@
                             <td data-order="{{ diaryentry.timestampWhen|date('U') }}">{{ diaryentry.timestampWhen ? diaryentry.timestampWhen|date('d.m.Y') : '' }}</td>
                             <td data-order="{{ diaryentry.modifiedAt|date('U') }}">{{ diaryentry.modifiedAt ? diaryentry.modifiedAt|date('d.m.Y H:i') : '' }} {% trans %}Uhr{% endtrans %}</td>
                             <td align="center">
-                                <a href="{{ path('diaryentry_edit', {'id': diaryentry.id}) }}" title="{% trans %}Bearbeiten{% endtrans %}" class="text-diary"><i class="fas fa-fw fa-edit"></i></a>
+                                {# Edit is removed once the user has migrated or the phase blocks
+                                   writes — server-side MigrationLockdownSubscriber also blocks it. #}
+                                {% if is_locked %}
+                                    <i class="fas fa-fw fa-lock text-muted" title="{{ locked_title }}"></i>
+                                {% else %}
+                                    <a href="{{ path('diaryentry_edit', {'id': diaryentry.id}) }}" title="{% trans %}Bearbeiten{% endtrans %}" class="text-diary"><i class="fas fa-fw fa-edit"></i></a>
+                                {% endif %}
                             </td>
                         </tr>
                     {% else %}

--- a/templates/app/diaryentry/show.html.twig
+++ b/templates/app/diaryentry/show.html.twig
@@ -31,9 +31,11 @@
                         <label for="SeizureDate">{% trans %}Zuletzt bearbeitet{% endtrans %}</label>
                         <input type="text" class="form-control" id="SeizureDate" value="{{ diaryentry.modifiedAt ? diaryentry.modifiedAt|date('d.m.Y H:i') : '' }} Uhr" readonly>
                     </div>
+                    {% if not is_locked %}
                     <div class="form-group">
                         <button type="button" class="btn btn-primary"><a style="color: #FFFFFF" href="{{ path('diaryentry_edit', {'id': diaryentry.id}) }}">{% trans %}Bearbeiten{% endtrans %}</a></button>
                     </div>
+                    {% endif %}
                 </form>
 
             </div>

--- a/templates/app/event/index.html.twig
+++ b/templates/app/event/index.html.twig
@@ -6,9 +6,11 @@
     <div class="mb-5">
         <div class="text-center">
             <h1 class="h3 text-gray-800 justify-content-center border-bottom pb-2 mb-2">{% trans %}Ereignis - Übersicht{% endtrans %}</h1>
-            <p class="mb-4">{% trans %}Untenstehend findest du alle deine erfassten{% endtrans %} {% trans %}Ereignisse{% endtrans %}. <br />{% trans %}Zusätzlich kannst du auf das Pluszeichen{% endtrans %} <i class="fas fa-plus-circle"></i> {% trans %}klicken, um ein neues Ereignis zu erstellen{% endtrans %}</p>
+            <p class="mb-4">{% trans %}Untenstehend findest du alle deine erfassten{% endtrans %} {% trans %}Ereignisse{% endtrans %}.{% if not is_locked %} <br />{% trans %}Zusätzlich kannst du auf das Pluszeichen{% endtrans %} <i class="fas fa-plus-circle"></i> {% trans %}klicken, um ein neues Ereignis zu erstellen{% endtrans %}{% endif %}</p>
 
+            {% if not is_locked %}
             <a href="{{ path('event_new') }}" title="{% trans %}Neues Ereignis erstellen{% endtrans %}"><i class="fas fa-plus-circle fa-3x text-event"></i></a>
+            {% endif %}
         </div>
     </div>
 
@@ -37,7 +39,13 @@
                             <td data-order="{{ event.timestampWhen|date('U') }}">{{ event.timestampWhen ? event.timestampWhen|date('d.m.Y') : '' }}</td>
                             <td data-order="{{ event.modifiedAt|date('U') }}">{{ event.modifiedAt ? event.modifiedAt|date('d.m.Y H:i') : '' }} {% trans %}Uhr{% endtrans %}</td>
                             <td align="center">
-                                <a href="{{ path('event_edit', {'id': event.id}) }}" title="{% trans %}Bearbeiten{% endtrans %}" class="text-event"><i class="fas fa-fw fa-edit"></i></a>
+                                {# Edit is removed once the user has migrated or the phase blocks
+                                   writes — server-side MigrationLockdownSubscriber also blocks it. #}
+                                {% if is_locked %}
+                                    <i class="fas fa-fw fa-lock text-muted" title="{{ locked_title }}"></i>
+                                {% else %}
+                                    <a href="{{ path('event_edit', {'id': event.id}) }}" title="{% trans %}Bearbeiten{% endtrans %}" class="text-event"><i class="fas fa-fw fa-edit"></i></a>
+                                {% endif %}
                             </td>
                         </tr>
                     {% else %}

--- a/templates/app/event/show.html.twig
+++ b/templates/app/event/show.html.twig
@@ -31,9 +31,11 @@
                         <label for="EventLastModified">{% trans %}Zuletzt bearbeitet{% endtrans %}</label>
                         <input type="text" class="form-control" id="EventLastModified" value="{{ event.modifiedAt ? event.modifiedAt|date('d.m.Y H:i') : '' }} {% trans %}Uhr{% endtrans %}" readonly>
                     </div>
+                    {% if not is_locked %}
                     <div class="form-group">
                         <button type="button" class="btn btn-primary"><a style="color: #FFFFFF" href="{{ path('event_edit', {'id': event.id}) }}">{% trans %}Bearbeiten{% endtrans %}</a></button>
                     </div>
+                    {% endif %}
                 </form>
             </div>
         </div>

--- a/templates/app/medication/index.html.twig
+++ b/templates/app/medication/index.html.twig
@@ -7,9 +7,11 @@
     <div class="mb-5">
         <div class="text-center">
             <h1 class="h3 text-gray-800 justify-content-center border-bottom pb-2 mb-2">{% trans %}Medikation - Übersicht{% endtrans %}</h1>
-            <p class="mb-4">{% trans %}Untenstehend findest du alle deine erfassten{% endtrans %} {% trans %}Medikationen{% endtrans %}. <br />{% trans %}Zusätzlich kannst du auf das Pluszeichen{% endtrans %} <i class="fas fa-plus-circle"></i> {% trans %}klicken, um eine neue Medikation zu erstellen{% endtrans %}</p>
+            <p class="mb-4">{% trans %}Untenstehend findest du alle deine erfassten{% endtrans %} {% trans %}Medikationen{% endtrans %}.{% if not is_locked %} <br />{% trans %}Zusätzlich kannst du auf das Pluszeichen{% endtrans %} <i class="fas fa-plus-circle"></i> {% trans %}klicken, um eine neue Medikation zu erstellen{% endtrans %}{% endif %}</p>
 
+            {% if not is_locked %}
             <a href="{{ path('medication_new') }}" title="{% trans %}Neue Medikation erstellen{% endtrans %}"><i class="fas fa-plus-circle fa-3x text-medication"></i></a>
+            {% endif %}
         </div>
     </div>
 
@@ -47,7 +49,13 @@
                           <!--  <td data-order="{{ medication.timestampPrescription|date('U') }}">{{ medication.timestampPrescription ? medication.timestampPrescription|date('d.m.Y')}}</td>-->
                             <td data-order="{{ medication.modifiedAt|date('U') }}">{{ medication.modifiedAt ? medication.modifiedAt|date('d.m.Y H:i') : '' }} {% trans %}Uhr{% endtrans %}</td>
                             <td align="center">
-                                <a href="{{ path('medication_edit', {'id': medication.id}) }}" title="{% trans %}Bearbeiten{% endtrans %}" class="text-medication"><i class="fas fa-fw fa-edit" ></i></a>
+                                {# Edit is removed once the user has migrated or the phase blocks
+                                   writes — server-side MigrationLockdownSubscriber also blocks it. #}
+                                {% if is_locked %}
+                                    <i class="fas fa-fw fa-lock text-muted" title="{{ locked_title }}"></i>
+                                {% else %}
+                                    <a href="{{ path('medication_edit', {'id': medication.id}) }}" title="{% trans %}Bearbeiten{% endtrans %}" class="text-medication"><i class="fas fa-fw fa-edit" ></i></a>
+                                {% endif %}
                             </td>
                         </tr>
                     {% else %}

--- a/templates/app/medication/show.html.twig
+++ b/templates/app/medication/show.html.twig
@@ -39,9 +39,11 @@
                         <label for="MedicationPrescriptionDate">{% trans %}Verschreibungsdatum{% endtrans %}</label>
                         <input type="text" class="form-control" id="MedicationPrescriptionDate" value="{{ medication.timestampPrescription ? medication.timestampPrescription|date('d.m.Y') : ''  }}" readonly>
                     </div>
+                    {% if not is_locked %}
                     <div class="form-group">
                         <button type="button" class="btn btn-primary"><a style="color: #FFFFFF" href="{{ path('medication_edit', {'id': medication.id}) }}">{% trans %}Bearbeiten{% endtrans %}</a></button>
                     </div>
+                    {% endif %}
 
                 </form>
 

--- a/templates/app/seizure/index.html.twig
+++ b/templates/app/seizure/index.html.twig
@@ -7,9 +7,11 @@
     <div class="mb-5">
         <div class="text-center">
             <h1 class="h3 text-gray-800 justify-content-center border-bottom pb-2 mb-2">{% trans %}Anfälle{% endtrans %} - {% trans %}Übersicht{% endtrans %}</h1>
-            <p class="mb-4">{% trans %}Untenstehend findest du alle deine erfassten{% endtrans %} {% trans %}Anfälle{% endtrans %}.<br />{% trans %}Zusätzlich kannst du auf das Pluszeichen{% endtrans %} <i class="fas fa-plus-circle"></i> {% trans %}klicken, um einen neuen Anfall zu erstellen{% endtrans %}</p>
+            <p class="mb-4">{% trans %}Untenstehend findest du alle deine erfassten{% endtrans %} {% trans %}Anfälle{% endtrans %}.{% if not is_locked %}<br />{% trans %}Zusätzlich kannst du auf das Pluszeichen{% endtrans %} <i class="fas fa-plus-circle"></i> {% trans %}klicken, um einen neuen Anfall zu erstellen{% endtrans %}{% endif %}</p>
 
+            {% if not is_locked %}
             <a href="{{ path('seizure_new') }}" title="{% trans %}Neuer Anfall erstellen{% endtrans %}"><i class="fas fa-plus-circle fa-3x text-seizure" ></i></a>
+            {% endif %}
         </div>
     </div>
 
@@ -36,7 +38,13 @@
                             <td data-order="{{ seizure.timestampWhen|date('U')  }}">{{ seizure.timestampWhen ? seizure.timestampWhen|date('d.m.Y H:i') : '' }} {% trans %}Uhr{% endtrans %}</td>
                             <td data-order="{{ seizure.modifiedAt|date('U')  }}">{{ seizure.modifiedAt ? seizure.modifiedAt|date('d.m.Y H:i') : '' }} {% trans %}Uhr{% endtrans %}</td>
                             <td align="center">
-                                <a href="{{ path('seizure_edit', {'id': seizure.id}) }}" title="{% trans %}Bearbeiten{% endtrans %}" class="text-seizure"><i class="fas fa-fw fa-edit"></i></a>
+                                {# Edit is removed once the user has migrated or the phase blocks
+                                   writes — server-side MigrationLockdownSubscriber also blocks it. #}
+                                {% if is_locked %}
+                                    <i class="fas fa-fw fa-lock text-muted" title="{{ locked_title }}"></i>
+                                {% else %}
+                                    <a href="{{ path('seizure_edit', {'id': seizure.id}) }}" title="{% trans %}Bearbeiten{% endtrans %}" class="text-seizure"><i class="fas fa-fw fa-edit"></i></a>
+                                {% endif %}
                             </td>
                         </tr>
                     {% else %}

--- a/templates/app/seizure/show.html.twig
+++ b/templates/app/seizure/show.html.twig
@@ -36,9 +36,11 @@
                         <input type="text" class="form-control" id="SeizureDate" value="{{ seizure.seizuretype.name|trans }}" readonly>
                     </div>
 
+                    {% if not is_locked %}
                     <div class="form-group">
                         <button type="button" class="btn btn-primary"><a style="color: #FFFFFF" href="{{ path('seizure_edit', {'id': seizure.id}) }}">{% trans %}Bearbeiten{% endtrans %}</a></button>
                     </div>
+                    {% endif %}
 
                 </form>
 

--- a/templates/landing/index.html.twig
+++ b/templates/landing/index.html.twig
@@ -9,7 +9,7 @@
                 <li><a href="#first">{% trans %}Funktionen{% endtrans %}</a></li>
                 <li><a href="#second">{% trans %}Sicherheit{% endtrans %}</a></li>
                 <li><a href="#cta">{% trans %}Los geht's{% endtrans %}</a></li>
-                <li><a href="{{ path('app_landingpage_info_ciphra') }}" style="font-weight: 600;">{% trans %}Wechsel zu ciphra{% endtrans %}</a></li>
+                <li><a href="{{ path('app_landingpage_info_ciphra') }}">{% trans %}Über ciphra{% endtrans %}</a></li>
                 <li><a href="{{ path('app_login') }}">{% trans %}Login{% endtrans %}</a></li>
             </ul>
         </nav>

--- a/templates/user_admin/index.html.twig
+++ b/templates/user_admin/index.html.twig
@@ -13,6 +13,43 @@
         </div>
     </div>
 
+    {# Kennzahlen — über ALLE Benutzer per SQL gezählt, nicht über die aktuelle
+       Seite. So bleiben sie korrekt, egal welche Seite der Paginator zeigt. #}
+    <div class="row">
+        <div class="col-xl-3 col-md-6 mb-4">
+            <div class="card border-left-primary shadow h-100 py-2">
+                <div class="card-body">
+                    <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">Benutzer total</div>
+                    <div class="h5 mb-0 font-weight-bold text-gray-800">{{ total_count }}</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-3 col-md-6 mb-4">
+            <div class="card border-left-danger shadow h-100 py-2">
+                <div class="card-body">
+                    <div class="text-xs font-weight-bold text-danger text-uppercase mb-1">Administratoren</div>
+                    <div class="h5 mb-0 font-weight-bold text-gray-800">{{ admin_count }}</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-3 col-md-6 mb-4">
+            <div class="card border-left-warning shadow h-100 py-2">
+                <div class="card-body">
+                    <div class="text-xs font-weight-bold text-warning text-uppercase mb-1">Deaktiviert</div>
+                    <div class="h5 mb-0 font-weight-bold text-gray-800">{{ deactivated_count }}</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-3 col-md-6 mb-4">
+            <div class="card border-left-success shadow h-100 py-2">
+                <div class="card-body">
+                    <div class="text-xs font-weight-bold text-success text-uppercase mb-1">Zu ciphra migriert</div>
+                    <div class="h5 mb-0 font-weight-bold text-gray-800">{{ migrated_count }}</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
 
     <!-- DataTales Example -->
     <div class="card shadow mb-4">
@@ -79,12 +116,34 @@
                         </tr>
                     {% else %}
                         <tr>
-                            <td colspan="6">Keine Benutzer vorhanden</td>
+                            <td colspan="7">Keine Benutzer vorhanden</td>
                         </tr>
                     {% endfor %}
                     </tbody>
                 </table>
             </div>
+
+            {# Server-seitige Seitennavigation. Die Suche/Sortierung von DataTables
+               wirkt nur auf die aktuelle Seite — die Liste wird absichtlich
+               paginiert, damit nicht alle Benutzer entschlüsselt werden müssen. #}
+            {% if totalPages > 1 %}
+                <nav aria-label="Benutzer-Seiten" class="mt-3">
+                    <ul class="pagination justify-content-center mb-1">
+                        <li class="page-item {{ page <= 1 ? 'disabled' }}">
+                            <a class="page-link" href="{{ path('admin_user_index', {'page': page - 1}) }}" aria-label="Zurück">&laquo;</a>
+                        </li>
+                        {% for p in 1..totalPages %}
+                            <li class="page-item {{ p == page ? 'active' }}">
+                                <a class="page-link" href="{{ path('admin_user_index', {'page': p}) }}">{{ p }}</a>
+                            </li>
+                        {% endfor %}
+                        <li class="page-item {{ page >= totalPages ? 'disabled' }}">
+                            <a class="page-link" href="{{ path('admin_user_index', {'page': page + 1}) }}" aria-label="Weiter">&raquo;</a>
+                        </li>
+                    </ul>
+                </nav>
+            {% endif %}
+            <p class="text-center text-muted small mb-0">{{ total_count }} Benutzer · Seite {{ page }} von {{ totalPages }}</p>
         </div>
     </div>
 {% endblock %}
@@ -113,7 +172,12 @@
             "language": {
                 "url": "{{ asset('application/json/German.json'|trans) }}"
             },
-            "order": [[ 5, "desc" ]]
+            "order": [[ 5, "desc" ]],
+            // Server handles pagination — DataTables only sorts/filters the
+            // current page, so disable its own pager + info line to avoid a
+            // misleading "1 of 1" alongside the server pagination below.
+            "paging": false,
+            "info": false
         });
     });
 

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -300,6 +300,7 @@ Willkommen: Willkommen
 
 # Profile-card migration variants
 'Wechsel zu ciphra': 'Wechsel zu ciphra'
+'Über ciphra': 'Über ciphra'
 'Migriere jetzt zu ciphra': 'Migriere jetzt zu ciphra'
 'Wechsel zu ciphra — noch': 'Wechsel zu ciphra — noch'
 'ciphra ist die Weiterentwicklung von epilepc. Deine Daten werden auf deinem Gerät verschlüsselt — der Inhalt verlässt es nie unverschlüsselt. ciphra unterstützt auch andere Diagnosen als Epilepsie.': 'ciphra ist die Weiterentwicklung von epilepc. Deine Daten werden auf deinem Gerät verschlüsselt — der Inhalt verlässt es nie unverschlüsselt. ciphra unterstützt auch andere Diagnosen als Epilepsie.'

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -368,6 +368,7 @@
 'Zeit, deine Daten zu sichern oder zu übertragen.': 'time to back up or transfer your data.'
 'Danach werden alle Konten gelöscht.': 'After that, all accounts will be deleted.'
 'Wechsel zu ciphra': 'Switch to ciphra'
+'Über ciphra': 'About ciphra'
 
 # --- /info/ciphra explainer page (Slice 3 extended) ---
 'Der Wechsel läuft direkt zwischen deinem Browser und den beiden Diensten ab. Drei Schritte, eine Minute:': 'The migration happens directly between your browser and the two services. Three steps, one minute:'

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -358,6 +358,7 @@ Reflex-Anfälle: 'Crises réflexes'
 'Zeit, deine Daten zu sichern oder zu übertragen.': 'pour sauvegarder ou transférer tes données.'
 'Danach werden alle Konten gelöscht.': 'Ensuite, tous les comptes seront supprimés.'
 'Wechsel zu ciphra': 'Passer à ciphra'
+'Über ciphra': 'À propos de ciphra'
 
 # --- /info/ciphra explainer page (Slice 3 extended) ---
 'Der Wechsel läuft direkt zwischen deinem Browser und den beiden Diensten ab. Drei Schritte, eine Minute:': 'La migration se déroule directement entre ton navigateur et les deux services. Trois étapes, une minute :'

--- a/translations/messages.it.yml
+++ b/translations/messages.it.yml
@@ -368,6 +368,7 @@
 'Zeit, deine Daten zu sichern oder zu übertragen.': 'per salvare o trasferire i tuoi dati.'
 'Danach werden alle Konten gelöscht.': 'Successivamente, tutti gli account verranno eliminati.'
 'Wechsel zu ciphra': 'Passa a ciphra'
+'Über ciphra': 'Informazioni su ciphra'
 
 # --- /info/ciphra explainer page (Slice 3 extended) ---
 'Der Wechsel läuft direkt zwischen deinem Browser und den beiden Diensten ab. Drei Schritte, eine Minute:': 'Il passaggio avviene direttamente tra il tuo browser e i due servizi. Tre passaggi, un minuto:'


### PR DESCRIPTION
Bundles the fixes from this round (ciphra already live, low active-user count).

## Fixes
- **/de/admin 500** — the admin user list called `findAll()` and decrypted firstname+lastname for *every* user. Defuse uses password-based encryption (PBKDF2 ~74ms/field), so the page blew past the host's hard 30s cap at ~200 users (`set_time_limit` is ignored under the `php74` CGI handler). Now server-paginated (25/page); overview metric cards (total / admins / deactivated / migrated) are counted via SQL `COUNT()` over **all** users, so they aren't limited to the page.
- **Lifecycle banner ×** — the dismiss button overlapped the CTA. Reserved the top-right slot at all breakpoints and pinned the button's min/max-width+padding so the landing `main.css` button reset can't inflate it to ~204px.

## Read-only / migrated UX
- Overviews: per-row edit pencil → 🔒 lock icon; the "+" create icon and its "click the +" hint are hidden when locked.
- Detail views: "Bearbeiten" button hidden when locked.
- All gated on the existing `is_locked` flag (user migrated **or** phase blocks writes), complementing the server-side `MigrationLockdownSubscriber`.

## Nav
- Demoted the duplicate "Wechsel zu ciphra" header CTA to a neutral, readable "Über ciphra" wayfinding link (translated de/en/fr/it). The banner stays the single switch CTA; the link remains reachable after the banner is dismissed.

Verified on the dockerized stack: all pages 200, pagination across pages with correct counts, locked vs unlocked render confirmed, Twig/YAML/PHP lint clean.

## Not in this PR (flagged for follow-up)
- Migrated **admin** is still locked out of admin actions (subscriber doesn't exempt `ROLE_ADMIN`).
- The user-data overviews still load+decrypt all records (same decrypt-cost pattern as admin) for users with many entries.
