### PR TITLE
Admin: active-user metric (30/90d) for migration planning

### DIFF
--- a/src/Controller/UserAdminController.php
+++ b/src/Controller/UserAdminController.php
@@ -44,6 +44,12 @@ class UserAdminController extends AbstractController
             $paginator = $userRepository->findPaginated($page, $perPage);
         }
 
+        // Activity windows for the ciphra-migration push — distinct users who
+        // created/modified any record recently (no last_login column exists).
+        $now = new \DateTime();
+        $active30 = $userRepository->countActiveSince((clone $now)->modify('-30 days'));
+        $active90 = $userRepository->countActiveSince((clone $now)->modify('-90 days'));
+
         return $this->render('user_admin/index.html.twig', [
             'users' => $paginator,
             'page' => $page,
@@ -53,6 +59,8 @@ class UserAdminController extends AbstractController
             'admin_count' => $userRepository->countAdmins(),
             'deactivated_count' => $userRepository->countDeactivated(),
             'migrated_count' => $userRepository->countMigrated(),
+            'active_30_count' => $active30,
+            'active_90_count' => $active90,
         ]);
 
     }

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -82,6 +82,30 @@ class UserRepository extends ServiceEntityRepository
             ->getSingleScalarResult();
     }
 
+    /**
+     * Distinct users who created OR modified any record (seizure / event /
+     * medication / diaryentry) since $since. A proxy for "active users":
+     * epilepc has no last_login column, so record timestamps are the only
+     * retroactive activity signal — used to size the ciphra-migration push.
+     */
+    public function countActiveSince(\DateTimeInterface $since): int
+    {
+        // Raw UNION across the four content tables; UNION dedupes user_ids so
+        // COUNT(*) is the distinct active-user count. `event` is backticked
+        // because EVENT is a reserved word.
+        $sql =
+            'SELECT COUNT(*) FROM ('
+            . ' SELECT user_id FROM seizure WHERE created_at >= :s OR modified_at >= :s'
+            . ' UNION SELECT user_id FROM `event` WHERE created_at >= :s OR modified_at >= :s'
+            . ' UNION SELECT user_id FROM medication WHERE created_at >= :s OR modified_at >= :s'
+            . ' UNION SELECT user_id FROM diaryentry WHERE created_at >= :s OR modified_at >= :s'
+            . ') active';
+
+        return (int) $this->getEntityManager()->getConnection()
+            ->executeQuery($sql, ['s' => $since->format('Y-m-d H:i:s')])
+            ->fetchOne();
+    }
+
     public function translateMonth($month_name, $lang)
     {
 

--- a/templates/user_admin/index.html.twig
+++ b/templates/user_admin/index.html.twig
@@ -50,6 +50,30 @@
         </div>
     </div>
 
+    {# Migrations-Planung: "aktiv" = Benutzer mit einem Eintrag (Anfall/Ereignis/
+       Medikation/Tagebuch) erstellt oder bearbeitet im Zeitfenster. Proxy mangels
+       last_login-Feld — hilft zu entscheiden, wie schnell die Lifecycle-Phasen
+       verschärft werden können. #}
+    <h6 class="text-gray-600 text-uppercase font-weight-bold small mb-2">Aktivität (für Migrations-Planung)</h6>
+    <div class="row">
+        <div class="col-xl-3 col-md-6 mb-4">
+            <div class="card border-left-info shadow h-100 py-2">
+                <div class="card-body">
+                    <div class="text-xs font-weight-bold text-info text-uppercase mb-1">Aktiv (30 Tage)</div>
+                    <div class="h5 mb-0 font-weight-bold text-gray-800">{{ active_30_count }}<span class="text-gray-500 small font-weight-normal"> / {{ total_count }}</span></div>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-3 col-md-6 mb-4">
+            <div class="card border-left-info shadow h-100 py-2">
+                <div class="card-body">
+                    <div class="text-xs font-weight-bold text-info text-uppercase mb-1">Aktiv (90 Tage)</div>
+                    <div class="h5 mb-0 font-weight-bold text-gray-800">{{ active_90_count }}<span class="text-gray-500 small font-weight-normal"> / {{ total_count }}</span></div>
+                </div>
+            </div>
+        </div>
+    </div>
+
 
     <!-- DataTales Example -->
     <div class="card shadow mb-4">


### PR DESCRIPTION
Adds an **Aktivität (für Migrations-Planung)** section to the admin overview so the ciphra phase-tightening decision is data-driven instead of a hunch.

Two cards — **Aktiv (30 Tage)** and **Aktiv (90 Tage)** — show the count of distinct users (out of total) who created or modified any record (seizure / event / medication / diaryentry) in the window.

- No `last_login` column exists, so this uses record timestamps — the only **retroactive** activity signal (works on existing data immediately).
- `UserRepository::countActiveSince()` does a single UNION across the four content tables (timestamps are unencrypted → cheap); metrics are computed over all users, not the paginated page.

Verified on the dev stack: HTTP 200, cards render correct values vs raw SQL, PHP/Twig lint clean.

Note: this is record-activity, which *undercounts* users who log in only to read/export without creating entries. If you want true login activity going forward, a `last_login` stamp (nullable column + one line in the authenticator) is the follow-up — but it starts empty, so it's only useful prospectively.