### PR TITLE
Track-3 3.7/3.8: document TRUSTED_HOSTS + TRUSTED_PROXIES for the migration off-ramp

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -30,3 +30,36 @@ EPILEPC_LIFECYCLE_PHASE=normal
 # probably want to flip this back to 0 to avoid re-seed log spam.
 SEED_ON_BOOT=1
 SEED_USERS=2
+
+# ─── Reverse-proxy / host trust (Track-3 3.7 + 3.8) ───────────────────────
+# public/index.php reads these and calls Request::setTrustedProxies/Hosts.
+# Leave BLANK for local docker dev (direct PHP, no proxy in front). Set them
+# in PROD (.env.local or the hosting env), where epilepc is served on two
+# paths with different trust:
+#   - apex / www.epilepc.ch → behind Cloudflare
+#   - direct.epilepc.ch     → DNS-only, BYPASSES Cloudflare (the migration
+#                             export off-ramp, see CiphraMigrationController)
+#
+# 3.8 — TRUSTED_HOSTS: Host-header allow-list (anti Host-injection / cache
+# poisoning). index.php wraps it as setTrustedHosts([<this>]); it is a regex.
+# Must list EVERY host PHP is legitimately reached on (incl. any hosting
+# health-check host), or those requests 400. Prod value:
+#   TRUSTED_HOSTS=^(www\.|direct\.)?epilepc\.ch$
+#
+# 3.7 — TRUSTED_PROXIES: which upstreams may set X-Forwarded-For, so the
+# migration rate limiter (CiphraExportRateLimiter, keyed on getClientIp())
+# sees the REAL client, not the proxy. NOTE: Symfony 4.4 has NO 'REMOTE_ADDR'
+# magic token (that landed in 5.3) — you must list explicit CIDRs. Set this
+# to Cloudflare's ranges:
+#   - apex/www: REMOTE_ADDR is a CF IP → CF-Connecting-IP / XFF trusted →
+#     per-user rate limiting. (Unset today → all CF users share ONE bucket.)
+#   - direct:   REMOTE_ADDR is the real client (not a CF range) → XFF
+#     IGNORED → un-spoofable. Correct on both paths.
+# ⚠️ VERIFY FIRST — if a Hostpoint reverse-proxy sits in front of PHP,
+# REMOTE_ADDR is the LB (not CF) and you must ALSO add the LB IP, or rate
+# limiting breaks. Check the already-recorded MigrationToken.ip_first_seen
+# rows (from the 233-entry test migration, which ran via direct.epilepc.ch):
+# real client IPs → no LB rewrite; all one internal IP → add that IP.
+#   TRUSTED_PROXIES=173.245.48.0/20,103.21.244.0/22,103.22.200.0/22,103.31.4.0/22,141.101.64.0/18,108.162.192.0/18,190.93.240.0/20,188.114.96.0/20,197.234.240.0/22,198.41.128.0/17,162.158.0.0/15,104.16.0.0/13,104.24.0.0/14,172.64.0.0/13,131.0.72.0/22,2400:cb00::/32,2606:4700::/32,2803:f800::/32,2405:b500::/32,2405:8100::/32,2a06:98c0::/29,2c0f:f248::/32
+TRUSTED_HOSTS=
+TRUSTED_PROXIES=


### PR DESCRIPTION
Closes the "direct.epilepc.ch has a different security posture" gap from the Track-2 migration bypass. **No code change** — `public/index.php` already reads `TRUSTED_PROXIES`/`TRUSTED_HOSTS` and calls `Request::setTrustedProxies/Hosts`; they were simply never set. This documents them (with prod values) in `.env.docker.example`.

### Context
epilepc serves the migration export on two ingress paths:
- **apex / www.epilepc.ch** → behind Cloudflare
- **direct.epilepc.ch** → DNS-only, **bypasses** Cloudflare (the off-ramp `CiphraMigrationController` uses for large bundles)

### 3.8 — `TRUSTED_HOSTS` (host-header allow-list)
`^(www\.|direct\.)?epilepc\.ch$` → blocks Host-injection / cache-poisoning. Must include every host PHP is legitimately reached on (incl. any hosting health-check host), or those 400.

### 3.7 — `TRUSTED_PROXIES` (real client IP for the rate limiter)
`CiphraExportRateLimiter` keys on `$request->getClientIp()`. Set to **Cloudflare's CIDRs** (full list in the file):
- **apex/www**: `REMOTE_ADDR` ∈ CF → `CF-Connecting-IP`/XFF trusted → per-user limiting (today, unset → all CF users share one bucket).
- **direct**: `REMOTE_ADDR` is the real client (not a CF range) → XFF **ignored** → un-spoofable. Correct on both paths.
- ⚠️ **Symfony 4.4** has no `REMOTE_ADDR` magic token (5.3+) → explicit CIDRs only.

### ⚠️ Verify before setting `TRUSTED_PROXIES` in prod
If a **Hostpoint reverse-proxy** sits in front of PHP, `REMOTE_ADDR` is the LB (not CF) and you must also add the LB IP, or rate limiting breaks. Check the already-recorded `MigrationToken.ip_first_seen` rows (from the 233-entry test migration via direct.epilepc.ch): real client IPs → no LB rewrite; all one internal IP → add it.

### Apply (operator)
Set the two vars in prod `.env.local` (or hosting env) with the values from the file comments, then recreate the app. Dev stays blank (no-op). epilepc decommissions 2026-10-01, so this only needs to hold for the migration window.